### PR TITLE
Fix `naver` of build docs to `NAVER Cloud`

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -123,7 +123,7 @@
             <a href="/docs/builders/lxd.html">LXD</a>
           </li>
           <li<%= sidebar_current("docs-builders-ncloud") %>>
-            <a href="/docs/builders/ncloud.html">Naver</a>
+            <a href="/docs/builders/ncloud.html">NAVER Cloud</a>
           </li>
           <li<%= sidebar_current("docs-builders-null") %>>
             <a href="/docs/builders/null.html">Null</a>


### PR DESCRIPTION
- Fix `naver` of build docs to `NAVER Cloud`